### PR TITLE
Parse stack sizes greater than 1000

### DIFF
--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -331,7 +331,7 @@ function parseStackSize (section: string[], item: ParsedItem) {
   }
   if (section[0].startsWith(_$[C.TAG_STACK_SIZE])) {
     // Portal Scroll "Stack Size: 2 448/40"
-    const [value, max] = section[0].substr(_$[C.TAG_STACK_SIZE].length).replace(/\u00a0/g, '').split('/').map(Number)
+    const [value, max] = section[0].substr(_$[C.TAG_STACK_SIZE].length).replace(/\u00a0/g, '').replace(/,/g, '').split('/').map(Number)
     item.stackSize = { value, max }
 
     if (item.category === ItemCategory.Seed) {


### PR DESCRIPTION
Fixes bug where stacks greater than 1000 have a comma for the thousand separator and fail to parse correctly. "1,234/20" gets parsed as 1 instead of 1234, for example.